### PR TITLE
Add vrefs to GC metanetkans

### DIFF
--- a/GroundConstruction-Core.netkan
+++ b/GroundConstruction-Core.netkan
@@ -3,6 +3,7 @@
     "identifier"   : "GroundConstruction-Core",
     "name"         : "Global Construction Core",
     "$kref"        : "#/ckan/spacedock/1123",
+    "$vref"        : "#/ckan/ksp-avc/GroundConstruction.version",
     "abstract"     : "This is the core component of the Global Construction mod. It should only be installed as a dependency by other mods.",
     "author"       : [ "allista" ],
     "license"      : "MIT",

--- a/GroundConstruction.netkan
+++ b/GroundConstruction.netkan
@@ -3,6 +3,7 @@
     "identifier"   : "GroundConstruction",
     "name"         : "Global Construction",
     "$kref"        : "#/ckan/spacedock/1123",
+    "$vref"        : "#/ckan/ksp-avc/GroundConstruction.version",
     "abstract"     : "Build vessels directly on other planets and in orbit using light-weight kits of high-tech components, with energy and raw materials produced on-site from Ore.",
     "author"       : [ "allista" ],
     "license"      : "MIT",


### PR DESCRIPTION
A user reports that this mod's version compatibility is meant to be broader (1.6.1 through 1.7.2):

https://forum.kerbalspaceprogram.com/index.php?/topic/154922-ckan-the-comprehensive-kerbal-archive-network-v1264-orion/&do=findComment&comment=3660965

And indeed there's a .version file in the download that says that.

This pull request adds `$vref` properties to the netkans to make the .version file's data populate into CKAN the next time the NetKAN bot runs.